### PR TITLE
add branchMaxLen to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ override as many or as few options as you like:
   "showVirtualEnv": true,
   "showCwd": true,
   "cwdMaxLength": 10,
+  "branchMaxLength": 12,
   "batteryWarn": 20,
   "showGit": true,
   "showHg": true,


### PR DESCRIPTION
I went looking to see if I could increase the length of the branch name, and I found that you'd already implemented it, this just adds the configuration variable to the README so that it's a little more easily discoverable.
